### PR TITLE
[iOS] feat #36: mock api 구현 및 활용

### DIFF
--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		F48583CB2A13802E00322C9F /* MockResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583C62A13802E00322C9F /* MockResponse.swift */; };
 		F48583CC2A13802E00322C9F /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583C72A13802E00322C9F /* NetworkError.swift */; };
 		F48583CF2A1380D100322C9F /* IssueListDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583CE2A1380D100322C9F /* IssueListDTO.swift */; };
+		F48583D12A138DA400322C9F /* issues.json in Resources */ = {isa = PBXBuildFile; fileRef = F48583D02A138DA400322C9F /* issues.json */; };
 		F4BF7CCC2A0C8886001C22F0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BF7CCB2A0C8886001C22F0 /* AppDelegate.swift */; };
 		F4BF7CCE2A0C8886001C22F0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BF7CCD2A0C8886001C22F0 /* SceneDelegate.swift */; };
 		F4BF7CD32A0C8886001C22F0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F4BF7CD12A0C8886001C22F0 /* Main.storyboard */; };
@@ -43,6 +44,7 @@
 		F48583C62A13802E00322C9F /* MockResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockResponse.swift; sourceTree = "<group>"; };
 		F48583C72A13802E00322C9F /* NetworkError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		F48583CE2A1380D100322C9F /* IssueListDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueListDTO.swift; sourceTree = "<group>"; };
+		F48583D02A138DA400322C9F /* issues.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = issues.json; sourceTree = "<group>"; };
 		F4BF7CC82A0C8886001C22F0 /* IssueTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IssueTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4BF7CCB2A0C8886001C22F0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F4BF7CCD2A0C8886001C22F0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 		F4BF7CE52A0C8B9F001C22F0 /* Resource */ = {
 			isa = PBXGroup;
 			children = (
+				F48583D02A138DA400322C9F /* issues.json */,
 				F4BF7CD42A0C8887001C22F0 /* Assets.xcassets */,
 			);
 			path = Resource;
@@ -233,6 +236,7 @@
 				F40809732A0DE2470005E0AB /* IssueList.storyboard in Resources */,
 				F4BF7CD52A0C8887001C22F0 /* Assets.xcassets in Resources */,
 				F4BF7CD32A0C8886001C22F0 /* Main.storyboard in Resources */,
+				F48583D12A138DA400322C9F /* issues.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		F40809732A0DE2470005E0AB /* IssueList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F40809722A0DE2470005E0AB /* IssueList.storyboard */; };
 		F40809752A0DE61C0005E0AB /* IssueListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40809742A0DE61C0005E0AB /* IssueListViewController.swift */; };
 		F48583AC2A10E1FC00322C9F /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583AB2A10E1FC00322C9F /* TabBarController.swift */; };
+		F48583C82A13802E00322C9F /* URLSessionDataTaskInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583C32A13802E00322C9F /* URLSessionDataTaskInterface.swift */; };
+		F48583C92A13802E00322C9F /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583C42A13802E00322C9F /* NetworkManager.swift */; };
+		F48583CA2A13802E00322C9F /* URLSessionInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583C52A13802E00322C9F /* URLSessionInterface.swift */; };
+		F48583CB2A13802E00322C9F /* MockResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583C62A13802E00322C9F /* MockResponse.swift */; };
+		F48583CC2A13802E00322C9F /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583C72A13802E00322C9F /* NetworkError.swift */; };
+		F48583CF2A1380D100322C9F /* IssueListDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48583CE2A1380D100322C9F /* IssueListDTO.swift */; };
 		F4BF7CCC2A0C8886001C22F0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BF7CCB2A0C8886001C22F0 /* AppDelegate.swift */; };
 		F4BF7CCE2A0C8886001C22F0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BF7CCD2A0C8886001C22F0 /* SceneDelegate.swift */; };
 		F4BF7CD32A0C8886001C22F0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F4BF7CD12A0C8886001C22F0 /* Main.storyboard */; };
@@ -31,6 +37,12 @@
 		F40809722A0DE2470005E0AB /* IssueList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = IssueList.storyboard; sourceTree = "<group>"; };
 		F40809742A0DE61C0005E0AB /* IssueListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListViewController.swift; sourceTree = "<group>"; };
 		F48583AB2A10E1FC00322C9F /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		F48583C32A13802E00322C9F /* URLSessionDataTaskInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskInterface.swift; sourceTree = "<group>"; };
+		F48583C42A13802E00322C9F /* NetworkManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		F48583C52A13802E00322C9F /* URLSessionInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionInterface.swift; sourceTree = "<group>"; };
+		F48583C62A13802E00322C9F /* MockResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockResponse.swift; sourceTree = "<group>"; };
+		F48583C72A13802E00322C9F /* NetworkError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		F48583CE2A1380D100322C9F /* IssueListDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueListDTO.swift; sourceTree = "<group>"; };
 		F4BF7CC82A0C8886001C22F0 /* IssueTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IssueTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4BF7CCB2A0C8886001C22F0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F4BF7CCD2A0C8886001C22F0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -84,6 +96,27 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
+		F48583C22A13802E00322C9F /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				F48583CD2A1380C300322C9F /* DTO */,
+				F48583C72A13802E00322C9F /* NetworkError.swift */,
+				F48583C42A13802E00322C9F /* NetworkManager.swift */,
+				F48583C52A13802E00322C9F /* URLSessionInterface.swift */,
+				F48583C32A13802E00322C9F /* URLSessionDataTaskInterface.swift */,
+				F48583C62A13802E00322C9F /* MockResponse.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		F48583CD2A1380C300322C9F /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				F48583CE2A1380D100322C9F /* IssueListDTO.swift */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
 		F4BF7CBF2A0C8886001C22F0 = {
 			isa = PBXGroup;
 			children = (
@@ -104,6 +137,7 @@
 		F4BF7CCA2A0C8886001C22F0 /* IssueTracker */ = {
 			isa = PBXGroup;
 			children = (
+				F48583C22A13802E00322C9F /* Network */,
 				F4BF7CD62A0C8887001C22F0 /* LaunchScreen.storyboard */,
 				F4BF7CD12A0C8886001C22F0 /* Main.storyboard */,
 				F48583AB2A10E1FC00322C9F /* TabBarController.swift */,
@@ -232,13 +266,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				F4BF7CF72A0D231D001C22F0 /* UILabel+font.swift in Sources */,
+				F48583CC2A13802E00322C9F /* NetworkError.swift in Sources */,
 				F4BF7CF32A0D1312001C22F0 /* Color.swift in Sources */,
 				F48583AC2A10E1FC00322C9F /* TabBarController.swift in Sources */,
+				F48583C82A13802E00322C9F /* URLSessionDataTaskInterface.swift in Sources */,
+				F48583CA2A13802E00322C9F /* URLSessionInterface.swift in Sources */,
+				F48583C92A13802E00322C9F /* NetworkManager.swift in Sources */,
+				F48583CF2A1380D100322C9F /* IssueListDTO.swift in Sources */,
 				F4BF7CF52A0D13FF001C22F0 /* TypoGraphy.swift in Sources */,
 				6343A0662A0F7B65005FFC3E /* IssueLabel.swift in Sources */,
 				F40809752A0DE61C0005E0AB /* IssueListViewController.swift in Sources */,
 				F4BF7CCC2A0C8886001C22F0 /* AppDelegate.swift in Sources */,
 				F4BF7CCE2A0C8886001C22F0 /* SceneDelegate.swift in Sources */,
+				F48583CB2A13802E00322C9F /* MockResponse.swift in Sources */,
 				638659DB2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/IssueTracker/IssueTracker/IssueTab/IssueListCollectionViewCell.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/IssueListCollectionViewCell.swift
@@ -12,6 +12,16 @@ class IssueListCollectionViewCell: UICollectionViewCell {
     @IBOutlet var descriptionLabel: UILabel!
     @IBOutlet var milestoneLabel: UILabel!
     @IBOutlet var labelStackView: UIStackView!
+  
+  override func awakeFromNib() {
+      super.awakeFromNib()
+      configureFont()
+    }
+    
+    override func prepareForReuse() {
+      super.prepareForReuse()
+      emptyLabelStack()
+    }
     
     func configureFont() {
         self.titleLabel.apply(typography: TypoGraphy(weight: .bold,
@@ -27,5 +37,20 @@ class IssueListCollectionViewCell: UICollectionViewCell {
     
     func addLabel(name: String, color: String) {
         self.labelStackView.addArrangedSubview(IssueLabel(name: name, color: color))
+    }
+  
+  func configure(issue: IssueListDTO.Issue) {
+      titleLabel.text = issue.title
+      descriptionLabel.text = issue.description
+      milestoneLabel.text = issue.milestone
+      
+      for label in issue.labels {
+        let labelView = IssueLabel(name: label.title, color: label.color)
+        self.labelStackView.addArrangedSubview(labelView)
+      }
+    }
+  
+  func emptyLabelStack() {
+      labelStackView.arrangedSubviews.forEach { view in labelStackView.removeArrangedSubview(view) }
     }
 }

--- a/ios/IssueTracker/IssueTracker/IssueTab/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/IssueListViewController.swift
@@ -11,6 +11,9 @@ class IssueListViewController: UIViewController {
   
   @IBOutlet weak var collectionView: UICollectionView!
     let data = [["description", "#1429D6"], ["Label", "#A36139"], ["wood", "#B4A239"]]
+  
+  var networkManager: NetworkManager?
+  var objects: [IssueListDTO.Issue] = []
     
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -26,6 +29,13 @@ class IssueListViewController: UIViewController {
     if let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
       flowLayout.estimatedItemSize = .zero
     }
+    
+    let urlSession = MockURLSession(withJson: "issues")
+    networkManager = NetworkManager(session: urlSession)
+    
+    networkManager?.fetchIssueList(completion: { [weak self] dto in
+      self?.objects = dto.body
+    })
   }
 }
 
@@ -35,20 +45,14 @@ extension IssueListViewController: UICollectionViewDataSource {
   }
   
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return 3
+    return objects.count
   }
   
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     guard let cell = collectionView.dequeueReusableCell(
       withReuseIdentifier: "IssueListCollectionViewCell",
       for: indexPath) as? IssueListCollectionViewCell else { return UICollectionViewCell() }
-      cell.configureFont()
-      let cellData = data[indexPath.row]
-      cell.addLabel(name: cellData[0], color: cellData[1])
-      
-    
-    
-      
+    cell.configure(issue: objects[indexPath.item])
       return cell
   }
 }

--- a/ios/IssueTracker/IssueTracker/Network/DTO/IssueListDTO.swift
+++ b/ios/IssueTracker/IssueTracker/Network/DTO/IssueListDTO.swift
@@ -1,0 +1,25 @@
+//
+//  IssueListDTO.swift
+//  IssueTracker
+//
+//  Created by Effie on 2023/05/15.
+//
+
+import Foundation
+
+struct IssueListDTO: Codable {
+  struct Issue: Codable {
+    struct Label: Codable {
+      let title: String
+      let color: String
+    }
+    
+    let title: String
+    let description: String
+    let milestone: String
+    let labels: [Label]
+  }
+  
+  let status: Int
+  let body: [Issue]
+}

--- a/ios/IssueTracker/IssueTracker/Network/MockResponse.swift
+++ b/ios/IssueTracker/IssueTracker/Network/MockResponse.swift
@@ -1,0 +1,35 @@
+//
+//  Response.swift
+//  IssueTracker
+//
+//  Created by Effie on 2023/05/16.
+//
+
+import Foundation
+
+struct MockResponse {
+  let data: Data?
+  let urlResponse: URLResponse?
+  let error: Error?
+  
+  init(fromJson jsonFileName: String) {
+    let fileName = jsonFileName
+    let json = ".json"
+    let path = Bundle.main.path(forResource: fileName, ofType: json) ?? ""
+    let fileURL = URL(filePath: path)
+    let mockData: Data? = try? Data(contentsOf: fileURL)
+    
+    let dummyURL = URL(string: "https://api.codesquad.kr/onban/main")!
+    let response = HTTPURLResponse(
+      url: dummyURL,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: [:])
+    
+    let error: Error? = nil
+    
+    self.data = mockData
+    self.urlResponse = response
+    self.error = error
+  }
+}

--- a/ios/IssueTracker/IssueTracker/Network/NetworkError.swift
+++ b/ios/IssueTracker/IssueTracker/Network/NetworkError.swift
@@ -1,0 +1,14 @@
+//
+//  NetworkError.swift
+//  IssueTracker
+//
+//  Created by Effie on 2023/05/15.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+  case noResponse
+  case invalidData
+  case failToParse
+}

--- a/ios/IssueTracker/IssueTracker/Network/NetworkManager.swift
+++ b/ios/IssueTracker/IssueTracker/Network/NetworkManager.swift
@@ -1,0 +1,71 @@
+//
+//  NetworkManager.swift
+//  IssueTracker
+//
+//  Created by Effie on 2023/05/15.
+//
+
+import Foundation
+
+final class NetworkManager {
+  static let dummyURLString = "https://api.codesquad.kr/onban/main"
+  
+  let session: URLSessionInterface
+  
+  init(session: URLSessionInterface = URLSession.shared) {
+    self.session = session
+  }
+  
+  func fetchData<T: Decodable>(
+    for urlString: String,
+    dataType: T.Type,
+    completion: @escaping (Result<T, Error>) -> Void)
+  {
+    guard let url = URL(string: urlString) else { return }
+    let request = URLRequest(url: url)
+    
+    let completionHandler = { (data: Data?, response: URLResponse?, error: Error?) in
+      if let error {
+        completion(.failure(error))
+        return
+      }
+      
+      guard let response = response as? HTTPURLResponse, (200..<300) ~= response.statusCode else {
+        completion(.failure(NetworkError.noResponse))
+        return
+      }
+      
+      guard let data else {
+        completion(.failure(NetworkError.invalidData))
+        return
+      }
+      
+      do {
+        let newData = try JSONDecoder().decode(dataType, from: data)
+        completion(.success(newData))
+        return
+      } catch {
+        completion(.failure(NetworkError.failToParse))
+        return
+      }
+    }
+    
+    let dataTask = session.dataTask(with: request, handler: completionHandler)
+    dataTask.resume()
+  }
+  
+  // MARK: - Util
+  
+  func fetchIssueList(completion: @escaping (IssueListDTO) -> Void) {
+    fetchData(for: Self.dummyURLString,
+              dataType: IssueListDTO.self) { result in
+      switch result {
+      case .success(let issueList):
+        completion(issueList)
+      case .failure(let error):
+        print(error)
+      }
+    }
+  }
+  
+}

--- a/ios/IssueTracker/IssueTracker/Network/URLSessionDataTaskInterface.swift
+++ b/ios/IssueTracker/IssueTracker/Network/URLSessionDataTaskInterface.swift
@@ -1,0 +1,26 @@
+//
+//  URLSessionDataTaskInterface.swift
+//  IssueTracker
+//
+//  Created by Effie on 2023/05/15.
+//
+
+import Foundation
+
+protocol URLSessionDataTaskInterface {
+  func resume()
+}
+
+extension URLSessionDataTask: URLSessionDataTaskInterface {}
+
+final class MockURLSessionDataTask: URLSessionDataTaskInterface {
+  private let resumeHandler: () -> Void
+  
+  init(resumeHandler: @escaping () -> Void) {
+    self.resumeHandler = resumeHandler
+  }
+  
+  func resume() {
+    resumeHandler()
+  }
+}

--- a/ios/IssueTracker/IssueTracker/Network/URLSessionInterface.swift
+++ b/ios/IssueTracker/IssueTracker/Network/URLSessionInterface.swift
@@ -1,0 +1,47 @@
+//
+//  URLSessionInterface.swift
+//  IssueTracker
+//
+//  Created by Effie on 2023/05/15.
+//
+
+import Foundation
+
+protocol URLSessionInterface {
+  func dataTask(
+    with request: URLRequest,
+    handler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void)
+  -> URLSessionDataTaskInterface
+}
+
+extension URLSession: URLSessionInterface {
+  func dataTask(
+    with request: URLRequest,
+    handler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void)
+  -> URLSessionDataTaskInterface
+  {
+    dataTask(with: request, completionHandler: handler)
+  }
+}
+
+final class MockURLSession: URLSessionInterface {
+  let mockResponse: MockResponse
+  
+  init(response: MockResponse) {
+    self.mockResponse = response
+  }
+  
+  convenience init(withJson jsonName: String) {
+    let response = MockResponse(fromJson: jsonName)
+    self.init(response: response)
+  }
+  
+  func dataTask(
+    with request: URLRequest,
+    handler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void)
+  -> URLSessionDataTaskInterface
+  {
+    let resumeHandler = { handler(self.mockResponse.data, self.mockResponse.urlResponse, self.mockResponse.error) }
+    return MockURLSessionDataTask(resumeHandler: resumeHandler)
+  }
+}

--- a/ios/IssueTracker/IssueTracker/Resource/issues.json
+++ b/ios/IssueTracker/IssueTracker/Resource/issues.json
@@ -1,0 +1,28 @@
+{
+  "status": 200,
+  "body": [
+    {
+      "title": "iOS 이슈트래커 개발",
+      "description": "2023년 5월 8일 월요일 부터",
+      "milestone": "그룹 프로젝트: 이슈트래커",
+      "labels": [
+        {
+          "title": "documentation",
+          "color": "#538661"
+        }
+      ]
+    },
+    {
+      "title": "UILabel Extension apply 메소드 수정",
+      "description": "line height 지정 함수로 인해 레이블이 2줄 이상\n생기지 않네요",
+      "milestone": "Issue-tracker",
+      "labels": [
+        {
+          "title": "Fix",
+          "color": "#FEFEFE"
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
실제 서비스를 대체할 mock api를 구성하고, issue list 에서 json 파일을 내려주는 api처럼 동작하도록 활용했습니다.

- URLSession의 dataTask ... 메소드와 URLSessionDataTask 의 resume 메소드를 갖는 인터페이스 작성
- 인터페이스를 구현하는 mock 클래스 작성 및 Foudation 클래스 extension 작성
- URLSession을 속성으로 갖는 NetworkManager 구현 
- fetching 메소드 작성 추가
- 실제 서비스할 데이터 모델과 동일한 DTO 모델 작성
- mock api로 사용할 json 파일 추가
- issue lising collection view에서 mock api 활용

@dpfdlalfm 실행 되는지 확인해부탁드립니다 !