### PR TITLE
[iOS] 이슈목록 필터 적용

### DIFF
--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		635342C42A21043100668765 /* UIColorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342C32A21043100668765 /* UIColorFactory.swift */; };
 		635342D42A22FEEA00668765 /* IssueFilterList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342D32A22FEEA00668765 /* IssueFilterList.swift */; };
 		635342D62A2303DD00668765 /* FilterListFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342D52A2303DD00668765 /* FilterListFactory.swift */; };
+		635342D82A23115300668765 /* FilterListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342D72A23115300668765 /* FilterListUseCase.swift */; };
+		635342DA2A23145F00668765 /* FilterListType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342D92A23145F00668765 /* FilterListType.swift */; };
 		638659D92A0D30AD006FE4F0 /* IssueListCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 638659D82A0D30AD006FE4F0 /* IssueListCollectionViewCell.xib */; };
 		638659DB2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638659DA2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift */; };
 		63D6CFCF2A15B7F6000876D5 /* FilterListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D6CFCE2A15B7F6000876D5 /* FilterListViewController.swift */; };
@@ -86,6 +88,8 @@
 		635342C32A21043100668765 /* UIColorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorFactory.swift; sourceTree = "<group>"; };
 		635342D32A22FEEA00668765 /* IssueFilterList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFilterList.swift; sourceTree = "<group>"; };
 		635342D52A2303DD00668765 /* FilterListFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListFactory.swift; sourceTree = "<group>"; };
+		635342D72A23115300668765 /* FilterListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListUseCase.swift; sourceTree = "<group>"; };
+		635342D92A23145F00668765 /* FilterListType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListType.swift; sourceTree = "<group>"; };
 		638659D82A0D30AD006FE4F0 /* IssueListCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueListCollectionViewCell.xib; sourceTree = "<group>"; };
 		638659DA2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListCollectionViewCell.swift; sourceTree = "<group>"; };
 		63D6CFCE2A15B7F6000876D5 /* FilterListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListViewController.swift; sourceTree = "<group>"; };
@@ -166,10 +170,12 @@
 			children = (
 				F4C0A6D22A21FF6D0045277D /* FilterList.storyboard */,
 				63D6CFCE2A15B7F6000876D5 /* FilterListViewController.swift */,
+				635342D72A23115300668765 /* FilterListUseCase.swift */,
 				63D6CFE42A168C0C000876D5 /* FilterListCollectionViewCell.xib */,
 				63D6CFE62A168F40000876D5 /* FilterListCollectionViewCell.swift */,
 				63D6CFE92A1698E7000876D5 /* FilterListCollectionViewHeader.xib */,
 				63D6CFE82A1698E7000876D5 /* FilterListCollectionViewHeader.swift */,
+				635342D92A23145F00668765 /* FilterListType.swift */,
 			);
 			path = Filter;
 			sourceTree = "<group>";
@@ -486,6 +492,7 @@
 				F4D5E3D72A1DE5CF00722AD1 /* CellIdentifiable.swift in Sources */,
 				F4A28CF22A1F56FB0091A940 /* LabelListDTO.swift in Sources */,
 				F48583CF2A1380D100322C9F /* IssueListDTO.swift in Sources */,
+				635342D82A23115300668765 /* FilterListUseCase.swift in Sources */,
 				F4BF7CF52A0D13FF001C22F0 /* Typography.swift in Sources */,
 				635342B22A20E56700668765 /* IssueDetailUseCase.swift in Sources */,
 				635342D42A22FEEA00668765 /* IssueFilterList.swift in Sources */,
@@ -500,6 +507,7 @@
 				6343A0662A0F7B65005FFC3E /* IssueLabel.swift in Sources */,
 				635342D62A2303DD00668765 /* FilterListFactory.swift in Sources */,
 				F4A28CCC2A1E2F700091A940 /* ListingItemFactory.swift in Sources */,
+				635342DA2A23145F00668765 /* FilterListType.swift in Sources */,
 				63D6CFCF2A15B7F6000876D5 /* FilterListViewController.swift in Sources */,
 				F4A28CEA2A1F3C6E0091A940 /* MilestoneList.swift in Sources */,
 				F40809752A0DE61C0005E0AB /* IssueListViewController.swift in Sources */,

--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		635342D62A2303DD00668765 /* FilterListFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342D52A2303DD00668765 /* FilterListFactory.swift */; };
 		635342D82A23115300668765 /* FilterListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342D72A23115300668765 /* FilterListUseCase.swift */; };
 		635342DA2A23145F00668765 /* FilterListType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342D92A23145F00668765 /* FilterListType.swift */; };
+		635342DC2A231F9000668765 /* FilterApplyList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342DB2A231F9000668765 /* FilterApplyList.swift */; };
 		638659D92A0D30AD006FE4F0 /* IssueListCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 638659D82A0D30AD006FE4F0 /* IssueListCollectionViewCell.xib */; };
 		638659DB2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638659DA2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift */; };
 		63D6CFCF2A15B7F6000876D5 /* FilterListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D6CFCE2A15B7F6000876D5 /* FilterListViewController.swift */; };
@@ -90,6 +91,7 @@
 		635342D52A2303DD00668765 /* FilterListFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListFactory.swift; sourceTree = "<group>"; };
 		635342D72A23115300668765 /* FilterListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListUseCase.swift; sourceTree = "<group>"; };
 		635342D92A23145F00668765 /* FilterListType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListType.swift; sourceTree = "<group>"; };
+		635342DB2A231F9000668765 /* FilterApplyList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterApplyList.swift; sourceTree = "<group>"; };
 		638659D82A0D30AD006FE4F0 /* IssueListCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueListCollectionViewCell.xib; sourceTree = "<group>"; };
 		638659DA2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListCollectionViewCell.swift; sourceTree = "<group>"; };
 		63D6CFCE2A15B7F6000876D5 /* FilterListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListViewController.swift; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 				63D6CFE92A1698E7000876D5 /* FilterListCollectionViewHeader.xib */,
 				63D6CFE82A1698E7000876D5 /* FilterListCollectionViewHeader.swift */,
 				635342D92A23145F00668765 /* FilterListType.swift */,
+				635342DB2A231F9000668765 /* FilterApplyList.swift */,
 			);
 			path = Filter;
 			sourceTree = "<group>";
@@ -481,6 +484,7 @@
 				F48583CC2A13802E00322C9F /* NetworkError.swift in Sources */,
 				F4A28CF82A1F77B20091A940 /* MilestoneListDTO.swift in Sources */,
 				63D6CFE72A168F40000876D5 /* FilterListCollectionViewCell.swift in Sources */,
+				635342DC2A231F9000668765 /* FilterApplyList.swift in Sources */,
 				F4BF7CF32A0D1312001C22F0 /* Color.swift in Sources */,
 				F48583AC2A10E1FC00322C9F /* TabBarController.swift in Sources */,
 				63D6CFD82A1624D3000876D5 /* DataSenderDelegate.swift in Sources */,

--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -20,10 +20,12 @@
 		635342C02A20FF3F00668765 /* IssueDetailHeaderData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342BF2A20FF3F00668765 /* IssueDetailHeaderData.swift */; };
 		635342C22A21032700668765 /* LastTimeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342C12A21032700668765 /* LastTimeGenerator.swift */; };
 		635342C42A21043100668765 /* UIColorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342C32A21043100668765 /* UIColorFactory.swift */; };
+		635342D42A22FEEA00668765 /* IssueFilterList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342D32A22FEEA00668765 /* IssueFilterList.swift */; };
+		635342D62A2303DD00668765 /* FilterListFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635342D52A2303DD00668765 /* FilterListFactory.swift */; };
 		638659D92A0D30AD006FE4F0 /* IssueListCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 638659D82A0D30AD006FE4F0 /* IssueListCollectionViewCell.xib */; };
 		638659DB2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638659DA2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift */; };
 		63D6CFCF2A15B7F6000876D5 /* FilterListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D6CFCE2A15B7F6000876D5 /* FilterListViewController.swift */; };
-		63D6CFD82A1624D3000876D5 /* DataSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D6CFD72A1624D3000876D5 /* DataSender.swift */; };
+		63D6CFD82A1624D3000876D5 /* DataSenderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D6CFD72A1624D3000876D5 /* DataSenderDelegate.swift */; };
 		63D6CFE52A168C0C000876D5 /* FilterListCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 63D6CFE42A168C0C000876D5 /* FilterListCollectionViewCell.xib */; };
 		63D6CFE72A168F40000876D5 /* FilterListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D6CFE62A168F40000876D5 /* FilterListCollectionViewCell.swift */; };
 		63D6CFEA2A1698E7000876D5 /* FilterListCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D6CFE82A1698E7000876D5 /* FilterListCollectionViewHeader.swift */; };
@@ -82,10 +84,12 @@
 		635342BF2A20FF3F00668765 /* IssueDetailHeaderData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailHeaderData.swift; sourceTree = "<group>"; };
 		635342C12A21032700668765 /* LastTimeGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastTimeGenerator.swift; sourceTree = "<group>"; };
 		635342C32A21043100668765 /* UIColorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorFactory.swift; sourceTree = "<group>"; };
+		635342D32A22FEEA00668765 /* IssueFilterList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFilterList.swift; sourceTree = "<group>"; };
+		635342D52A2303DD00668765 /* FilterListFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListFactory.swift; sourceTree = "<group>"; };
 		638659D82A0D30AD006FE4F0 /* IssueListCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueListCollectionViewCell.xib; sourceTree = "<group>"; };
 		638659DA2A0D3483006FE4F0 /* IssueListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListCollectionViewCell.swift; sourceTree = "<group>"; };
 		63D6CFCE2A15B7F6000876D5 /* FilterListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListViewController.swift; sourceTree = "<group>"; };
-		63D6CFD72A1624D3000876D5 /* DataSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSender.swift; sourceTree = "<group>"; };
+		63D6CFD72A1624D3000876D5 /* DataSenderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSenderDelegate.swift; sourceTree = "<group>"; };
 		63D6CFE42A168C0C000876D5 /* FilterListCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FilterListCollectionViewCell.xib; sourceTree = "<group>"; };
 		63D6CFE62A168F40000876D5 /* FilterListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListCollectionViewCell.swift; sourceTree = "<group>"; };
 		63D6CFE82A1698E7000876D5 /* FilterListCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListCollectionViewHeader.swift; sourceTree = "<group>"; };
@@ -177,6 +181,7 @@
 				F4BF7CF42A0D13FF001C22F0 /* Typography.swift */,
 				6343A0652A0F7B65005FFC3E /* IssueLabel.swift */,
 				F4A28CCB2A1E2F700091A940 /* ListingItemFactory.swift */,
+				635342D52A2303DD00668765 /* FilterListFactory.swift */,
 				635342C32A21043100668765 /* UIColorFactory.swift */,
 				635342C12A21032700668765 /* LastTimeGenerator.swift */,
 				F4A28CCD2A1E3A200091A940 /* SwipeAction.swift */,
@@ -270,6 +275,7 @@
 			isa = PBXGroup;
 			children = (
 				F4D5E3D32A1C50AF00722AD1 /* IssueList.swift */,
+				635342D32A22FEEA00668765 /* IssueFilterList.swift */,
 				F4A28CE12A1F23030091A940 /* LabelList.swift */,
 				F4A28CE92A1F3C6D0091A940 /* MilestoneList.swift */,
 				635342BF2A20FF3F00668765 /* IssueDetailHeaderData.swift */,
@@ -324,7 +330,7 @@
 				F48583AA2A0E21E500322C9F /* Extension */,
 				F48583C22A13802E00322C9F /* Network */,
 				F48583AB2A10E1FC00322C9F /* TabBarController.swift */,
-				63D6CFD72A1624D3000876D5 /* DataSender.swift */,
+				63D6CFD72A1624D3000876D5 /* DataSenderDelegate.swift */,
 				F4A28CFB2A1F7F060091A940 /* Model */,
 				F48583A92A0E21DA00322C9F /* IssueTab */,
 				F4A28CDB2A1E3D4A0091A940 /* LabelTab */,
@@ -471,7 +477,7 @@
 				63D6CFE72A168F40000876D5 /* FilterListCollectionViewCell.swift in Sources */,
 				F4BF7CF32A0D1312001C22F0 /* Color.swift in Sources */,
 				F48583AC2A10E1FC00322C9F /* TabBarController.swift in Sources */,
-				63D6CFD82A1624D3000876D5 /* DataSender.swift in Sources */,
+				63D6CFD82A1624D3000876D5 /* DataSenderDelegate.swift in Sources */,
 				F48583C82A13802E00322C9F /* URLSessionDataTaskInterface.swift in Sources */,
 				F415D2882A202F8B00712189 /* UITextField+font.swift in Sources */,
 				F48583CA2A13802E00322C9F /* URLSessionInterface.swift in Sources */,
@@ -482,6 +488,7 @@
 				F48583CF2A1380D100322C9F /* IssueListDTO.swift in Sources */,
 				F4BF7CF52A0D13FF001C22F0 /* Typography.swift in Sources */,
 				635342B22A20E56700668765 /* IssueDetailUseCase.swift in Sources */,
+				635342D42A22FEEA00668765 /* IssueFilterList.swift in Sources */,
 				635342BD2A20FAF800668765 /* IssueDetailCollectionViewHeader.swift in Sources */,
 				F4A28CED2A1F40B70091A940 /* MilestoneListCell.swift in Sources */,
 				F4A28CE22A1F23030091A940 /* LabelList.swift in Sources */,
@@ -491,6 +498,7 @@
 				F4A28CDF2A1E3F8E0091A940 /* LabelListCell.swift in Sources */,
 				F4D5E3D42A1C50AF00722AD1 /* IssueList.swift in Sources */,
 				6343A0662A0F7B65005FFC3E /* IssueLabel.swift in Sources */,
+				635342D62A2303DD00668765 /* FilterListFactory.swift in Sources */,
 				F4A28CCC2A1E2F700091A940 /* ListingItemFactory.swift in Sources */,
 				63D6CFCF2A15B7F6000876D5 /* FilterListViewController.swift in Sources */,
 				F4A28CEA2A1F3C6E0091A940 /* MilestoneList.swift in Sources */,

--- a/ios/IssueTracker/IssueTracker/Common/FilterListFactory.swift
+++ b/ios/IssueTracker/IssueTracker/Common/FilterListFactory.swift
@@ -1,0 +1,16 @@
+//
+//  FilterListFactory.swift
+//  IssueTracker
+//
+//  Created by Wood on 2023/05/28.
+//
+
+import Foundation
+
+struct FilterListFactory {
+   static func make(issueList: IssueListDTO) -> IssueFilterList {
+      return IssueFilterList(userList: issueList.userList,
+                             labelList: issueList.labelList,
+                             milestoneList: issueList.milestoneList)
+   }
+}

--- a/ios/IssueTracker/IssueTracker/DataSenderDelegate.swift
+++ b/ios/IssueTracker/IssueTracker/DataSenderDelegate.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 protocol DataSenderDelegate {
-   func receive() -> IssueListDTO
+   associatedtype DataType
+   
+   func send() -> DataType
 }

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterApplyList.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterApplyList.swift
@@ -8,20 +8,20 @@
 import Foundation
 
 class FilterApplyList {
-   private var status: Bool
-   private var users: Set<Int>
-   private var labels: Set<Int>
-   private var milestones: Set<Int>
+   var status: Bool
+   var users: Set<Int>
+   var labels: Set<Int>
+   var milestone: Int?
    
    init(status: Bool = true,
         users: Set<Int> = [],
         labels: Set<Int> = [],
-        milestones: Set<Int> = []) {
+        milestone: Int? = nil) {
       
       self.status = status
       self.users = users
       self.labels = labels
-      self.milestones = milestones
+      self.milestone = milestone
    }
    
    func addFilter(section: Int, id: Int?) {
@@ -29,14 +29,21 @@ class FilterApplyList {
       
       switch section {
       case 0:
-         break
+         self.status = id == 3 ? false : true
       case 1:
          self.users.insert(id)
       case 2:
          self.labels.insert(id)
       default:
-         self.milestones.insert(id)
+         self.milestone = id
       }
+   }
+   
+   func emptyList() {
+      self.status = true
+      self.users = []
+      self.labels = []
+      self.milestone = nil
    }
 }
 

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterApplyList.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterApplyList.swift
@@ -1,0 +1,45 @@
+//
+//  FilterApplyList.swift
+//  IssueTracker
+//
+//  Created by Wood on 2023/05/28.
+//
+
+import Foundation
+
+class FilterApplyList {
+   private var status: Bool
+   private var users: Set<Int>
+   private var labels: Set<Int>
+   private var milestones: Set<Int>
+   
+   init(status: Bool = true,
+        users: Set<Int> = [],
+        labels: Set<Int> = [],
+        milestones: Set<Int> = []) {
+      
+      self.status = status
+      self.users = users
+      self.labels = labels
+      self.milestones = milestones
+   }
+   
+   func addFilter(section: Int, id: Int?) {
+      guard let id = id else { return }
+      
+      switch section {
+      case 0:
+         break
+      case 1:
+         self.users.insert(id)
+      case 2:
+         self.labels.insert(id)
+      default:
+         self.milestones.insert(id)
+      }
+   }
+}
+
+extension FilterApplyList {
+   static let applyFilter = Notification.Name(rawValue: "applyFilter")
+}

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListCollectionViewCell.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListCollectionViewCell.swift
@@ -20,14 +20,14 @@ class FilterListCollectionViewCell: UICollectionViewCell {
       guard let checkmark = UIImage(systemName: "checkmark") else { return }
       let imageInset = UIEdgeInsets(top: -7, left: -7, bottom: -7, right: -7)
       self.selectionImageView.image = checkmark.withAlignmentRectInsets(imageInset)
-      self.selectionImageView.tintColor = .systemBlue
+      self.selectionImageView.tintColor = .systemGray
    }
    
    func setSelected() {
-      selectionImageView.tintColor = .systemGray
+      selectionImageView.tintColor = .systemBlue
    }
    
    func setDeselected() {
-      self.selectionImageView.tintColor = .systemBlue
+      self.selectionImageView.tintColor = .systemGray
    }
 }

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListCollectionViewCell.xib
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListCollectionViewCell.xib
@@ -3,6 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,6 +19,7 @@
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xtZ-Sz-Zbv">
                         <rect key="frame" x="565" y="22.666666666666671" width="30" height="30"/>
+                        <color key="tintColor" name="gray700"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="30" id="Ngq-iE-Qg3"/>
                             <constraint firstAttribute="height" constant="30" id="Sdq-hd-zZO"/>
@@ -47,4 +49,9 @@
             <point key="canvasLocation" x="967.17557251908397" y="54.577464788732399"/>
         </collectionViewCell>
     </objects>
+    <resources>
+        <namedColor name="gray700">
+            <color red="0.54117647058823526" green="0.54117647058823526" blue="0.58431372549019611" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListType.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListType.swift
@@ -1,0 +1,15 @@
+//
+//  FilterListType.swift
+//  IssueTracker
+//
+//  Created by Wood on 2023/05/28.
+//
+
+import Foundation
+
+enum FilterListType {
+   case status
+   case user
+   case label
+   case milestone
+}

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListUseCase.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListUseCase.swift
@@ -61,8 +61,8 @@ class FilterListUseCase {
    func sendItemId(section: Int, index: Int) -> Int {
       switch section {
       case 0:
-         guard index < 3 else { return 0 }
-         return 1
+         guard index < 3 else { return 1 }
+         return 0
       case 1:
          return self.filterList.userList[index].userId
       case 2:

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListUseCase.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListUseCase.swift
@@ -9,17 +9,27 @@ import Foundation
 
 class FilterListUseCase {
    private var filterList: IssueFilterList
-   var countAllStatus: Int
-   var countAllUsers: Int
-   var countAllLabels: Int
-   var countAllMilestones: Int
+   private var countAllHeaders: Int
+   private var countAllStatus: Int
+   private var countAllUsers: Int
+   private var countAllLabels: Int
+   private var countAllMilestones: Int
    
    init(filterList: IssueFilterList) {
       self.filterList = filterList
+      self.countAllHeaders = filterList.headerList.count
       self.countAllStatus = 4
       self.countAllUsers = filterList.userList.count
       self.countAllLabels = filterList.labelList.count
       self.countAllMilestones = filterList.milestoneList.count
+   }
+   
+   func sendHeaderCount() -> Int {
+      countAllHeaders
+   }
+   
+   func sendHeaderName(section: Int) -> String {
+      return self.filterList.headerList[section]
    }
    
    func sendCount(section: Int) -> Int {

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListUseCase.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListUseCase.swift
@@ -1,0 +1,50 @@
+//
+//  FilterListUseCase.swift
+//  IssueTracker
+//
+//  Created by Wood on 2023/05/28.
+//
+
+import Foundation
+
+class FilterListUseCase {
+   private var filterList: IssueFilterList
+   var countAllStatus: Int
+   var countAllUsers: Int
+   var countAllLabels: Int
+   var countAllMilestones: Int
+   
+   init(filterList: IssueFilterList) {
+      self.filterList = filterList
+      self.countAllStatus = 4
+      self.countAllUsers = filterList.userList.count
+      self.countAllLabels = filterList.labelList.count
+      self.countAllMilestones = filterList.milestoneList.count
+   }
+   
+   func sendCount(section: Int) -> Int {
+      switch section {
+      case 0:
+         return self.countAllStatus
+      case 1:
+         return self.countAllUsers
+      case 2:
+         return self.countAllLabels
+      default:
+         return self.countAllMilestones
+      }
+   }
+   
+   func sendItemName(section: Int, index: Int) -> String {
+      switch section {
+      case 0:
+         return self.filterList.statusList[index]
+      case 1:
+         return self.filterList.userList[index].userName
+      case 2:
+         return self.filterList.labelList[index].labelName
+      default:
+         return self.filterList.milestoneList[index].milestoneName ?? ""
+      }
+   }
+}

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListUseCase.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListUseCase.swift
@@ -57,4 +57,18 @@ class FilterListUseCase {
          return self.filterList.milestoneList[index].milestoneName ?? ""
       }
    }
+   
+   func sendItemId(section: Int, index: Int) -> Int {
+      switch section {
+      case 0:
+         guard index < 3 else { return 0 }
+         return 1
+      case 1:
+         return self.filterList.userList[index].userId
+      case 2:
+         return self.filterList.labelList[index].labelId
+      default:
+         return self.filterList.milestoneList[index].milestoneId
+      }
+   }
 }

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
@@ -21,6 +21,7 @@ class FilterListViewController: UIViewController {
    
    override func viewDidLoad() {
       super.viewDidLoad()
+      filterApplyList.emptyList()
       receiveData()
       setCollectionView()
    }
@@ -63,8 +64,8 @@ class FilterListViewController: UIViewController {
       }
       
       NotificationCenter.default.post(name: FilterApplyList.applyFilter,
-                                            object: nil,
-                                            userInfo: [0 : filterApplyList])
+                                      object: nil,
+                                      userInfo: [0 : filterApplyList])
       
       self.dismiss(animated: true)
    }

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
@@ -149,3 +149,21 @@ extension FilterListViewController: UICollectionViewDelegateFlowLayout {
       return UIEdgeInsets(top: 1.0, left: 0, bottom: 4.0, right: 0)
    }
 }
+
+extension FilterListViewController {
+   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+      guard let cell = collectionView.cellForItem(at: indexPath) as? FilterListCollectionViewCell else {
+         return
+      }
+      
+      cell.setSelected()
+   }
+   
+   func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+      guard let cell = collectionView.cellForItem(at: indexPath) as? FilterListCollectionViewCell else {
+         return
+      }
+      
+      cell.setDeselected()
+   }
+}

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
@@ -13,14 +13,14 @@ class FilterListViewController: UIViewController {
    let filterHeaderNames = ["상태", "담당자", "레이블", "마일스톤"]
    
    var delegate: (any DataSenderDelegate)?
-   var useCase = IssueFilterList()
-   let statusCellCount = 4
+   var useCase: FilterListUseCase?
    let sectionCount = 4
    
    @IBOutlet weak var collectionView: UICollectionView!
    
    override func viewDidLoad() {
       super.viewDidLoad()
+      loadData()
       setCollectionView()
    }
    
@@ -29,7 +29,7 @@ class FilterListViewController: UIViewController {
          return
       }
       
-      self.useCase = receivedData
+      self.useCase = FilterListUseCase(filterList: receivedData)
    }
    
    private func setCollectionView() {
@@ -53,7 +53,6 @@ class FilterListViewController: UIViewController {
    }
    
    @IBAction func save(_ sender: Any) {
-      
       self.dismiss(animated: true)
    }
 }
@@ -85,16 +84,11 @@ extension FilterListViewController: UICollectionViewDataSource {
       _ collectionView: UICollectionView,
       numberOfItemsInSection section: Int)
    -> Int {
-      switch section {
-      case 0:
-         return filterStatusList.count
-      case 1:
-         return useCase.userList.count
-      case 2:
-         return useCase.labelList.count
-      default:
-         return useCase.milestoneList.count
+      guard let countOfItems = useCase?.sendCount(section: section) else {
+         return 1
       }
+      
+      return countOfItems
    }
    
    func collectionView(
@@ -106,19 +100,12 @@ extension FilterListViewController: UICollectionViewDataSource {
          for: indexPath
       ) as? FilterListCollectionViewCell else { return UICollectionViewCell() }
       
-      let filterElement: String
-      switch indexPath.section {
-      case 0:
-         filterElement = filterStatusList[indexPath.row]
-      case 1:
-         filterElement = useCase.userList[indexPath.row].userName
-      case 2:
-         filterElement = useCase.labelList[indexPath.row].labelName
-      default:
-         filterElement = useCase.milestoneList[indexPath.row].milestoneName!
+      guard let itemName = useCase?.sendItemName(section: indexPath.section,
+                                                 index: indexPath.row) else {
+         return cell
       }
       
-      cell.filterName.text = filterElement
+      cell.filterName.text = itemName
       cell.configureFont()
       cell.configureImage()
       return cell

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
@@ -59,7 +59,11 @@ class FilterListViewController: UIViewController {
 
 extension FilterListViewController: UICollectionViewDataSource {
    func numberOfSections(in collectionView: UICollectionView) -> Int {
-      return sectionCount
+      guard let countOfSections = useCase?.sendHeaderCount() else {
+         return 0
+      }
+      
+      return countOfSections
    }
    
    func collectionView(
@@ -75,7 +79,11 @@ extension FilterListViewController: UICollectionViewDataSource {
          return UICollectionReusableView()
       }
       
-      header.sectionName.text = filterHeaderNames[indexPath.section]
+      guard let sectionName = useCase?.sendHeaderName(section: indexPath.section) else {
+         return header
+      }
+      
+      header.sectionName.text = sectionName
       header.configureFont()
       return header
    }
@@ -138,4 +146,8 @@ extension FilterListViewController: UICollectionViewDelegateFlowLayout {
                        insetForSectionAt section: Int) -> UIEdgeInsets {
       return UIEdgeInsets(top: 1.0, left: 0, bottom: 4.0, right: 0)
    }
+}
+
+extension FilterListViewController {
+   
 }

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
@@ -10,11 +10,10 @@ import UIKit
 class FilterListViewController: UIViewController {
    let filterCellID = "FilterListCollectionViewCell"
    let filterHeaderID = "FilterListCollectionViewHeader"
-   let filterStatusList = ["열린 이슈", "내가 작성한 이슈", "내가 댓글을 남긴 이슈", "닫힌 이슈"]
    let filterHeaderNames = ["상태", "담당자", "레이블", "마일스톤"]
    
-   var delegate: DataSenderDelegate?
-   var useCase = IssueListDTO()
+   var delegate: (any DataSenderDelegate)?
+   var useCase = IssueFilterList()
    let statusCellCount = 4
    let sectionCount = 4
    
@@ -22,14 +21,18 @@ class FilterListViewController: UIViewController {
    
    override func viewDidLoad() {
       super.viewDidLoad()
-      guard let receivedData = delegate?.receive() else {
-         return
-      }
-      useCase = receivedData
       setCollectionView()
    }
    
-   func setCollectionView() {
+   private func loadData() {
+      guard let receivedData = delegate?.send() as? IssueFilterList else {
+         return
+      }
+      
+      self.useCase = receivedData
+   }
+   
+   private func setCollectionView() {
       collectionView.delegate = self
       collectionView.dataSource = self
       
@@ -88,9 +91,9 @@ extension FilterListViewController: UICollectionViewDataSource {
       case 1:
          return useCase.userList.count
       case 2:
-         return useCase.countAllLabels
+         return useCase.labelList.count
       default:
-         return useCase.countAllMilestones
+         return useCase.milestoneList.count
       }
    }
    

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
@@ -10,26 +10,25 @@ import UIKit
 class FilterListViewController: UIViewController {
    let filterCellID = "FilterListCollectionViewCell"
    let filterHeaderID = "FilterListCollectionViewHeader"
-   let filterHeaderNames = ["상태", "담당자", "레이블", "마일스톤"]
    
    var delegate: (any DataSenderDelegate)?
-   var useCase: FilterListUseCase?
-   let sectionCount = 4
+   var filterListUseCase: FilterListUseCase?
+   var filterApplyList = FilterApplyList()
    
    @IBOutlet weak var collectionView: UICollectionView!
    
    override func viewDidLoad() {
       super.viewDidLoad()
-      loadData()
+      receiveData()
       setCollectionView()
    }
    
-   private func loadData() {
+   private func receiveData() {
       guard let receivedData = delegate?.send() as? IssueFilterList else {
          return
       }
       
-      self.useCase = FilterListUseCase(filterList: receivedData)
+      self.filterListUseCase = FilterListUseCase(filterList: receivedData)
    }
    
    private func setCollectionView() {
@@ -46,6 +45,8 @@ class FilterListViewController: UIViewController {
       if let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
          flowLayout.estimatedItemSize = .zero
       }
+      
+      collectionView.allowsMultipleSelection = true
    }
    
    @IBAction func cancel(_ sender: Any) {
@@ -53,13 +54,14 @@ class FilterListViewController: UIViewController {
    }
    
    @IBAction func save(_ sender: Any) {
+      
       self.dismiss(animated: true)
    }
 }
 
 extension FilterListViewController: UICollectionViewDataSource {
    func numberOfSections(in collectionView: UICollectionView) -> Int {
-      guard let countOfSections = useCase?.sendHeaderCount() else {
+      guard let countOfSections = filterListUseCase?.sendHeaderCount() else {
          return 0
       }
       
@@ -79,7 +81,7 @@ extension FilterListViewController: UICollectionViewDataSource {
          return UICollectionReusableView()
       }
       
-      guard let sectionName = useCase?.sendHeaderName(section: indexPath.section) else {
+      guard let sectionName = filterListUseCase?.sendHeaderName(section: indexPath.section) else {
          return header
       }
       
@@ -92,7 +94,7 @@ extension FilterListViewController: UICollectionViewDataSource {
       _ collectionView: UICollectionView,
       numberOfItemsInSection section: Int)
    -> Int {
-      guard let countOfItems = useCase?.sendCount(section: section) else {
+      guard let countOfItems = filterListUseCase?.sendCount(section: section) else {
          return 1
       }
       
@@ -108,7 +110,7 @@ extension FilterListViewController: UICollectionViewDataSource {
          for: indexPath
       ) as? FilterListCollectionViewCell else { return UICollectionViewCell() }
       
-      guard let itemName = useCase?.sendItemName(section: indexPath.section,
+      guard let itemName = filterListUseCase?.sendItemName(section: indexPath.section,
                                                  index: indexPath.row) else {
          return cell
       }
@@ -146,8 +148,4 @@ extension FilterListViewController: UICollectionViewDelegateFlowLayout {
                        insetForSectionAt section: Int) -> UIEdgeInsets {
       return UIEdgeInsets(top: 1.0, left: 0, bottom: 4.0, right: 0)
    }
-}
-
-extension FilterListViewController {
-   
 }

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
@@ -14,6 +14,8 @@ class FilterListViewController: UIViewController {
    var delegate: (any DataSenderDelegate)?
    var filterListUseCase: FilterListUseCase?
    var filterApplyList = FilterApplyList()
+   var pastSelectionStatus: IndexPath?
+   var pastSelectionMilestone: IndexPath?
    
    @IBOutlet weak var collectionView: UICollectionView!
    
@@ -160,15 +162,42 @@ extension FilterListViewController: UICollectionViewDelegateFlowLayout {
 }
 
 extension FilterListViewController {
-   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+   func collectionView(_ collectionView: UICollectionView,
+                       didSelectItemAt indexPath: IndexPath) {
       guard let cell = collectionView.cellForItem(at: indexPath) as? FilterListCollectionViewCell else {
          return
       }
       
+      switch indexPath.section {
+      case 0:
+         guard let pastSelectionIndexPath = pastSelectionStatus else {
+            pastSelectionStatus = indexPath
+            break
+         }
+         collectionView.deselectItem(at: pastSelectionIndexPath, animated: true)
+         let cell = collectionView.cellForItem(at: pastSelectionIndexPath) as? FilterListCollectionViewCell
+         cell?.setDeselected()
+         pastSelectionStatus = indexPath
+      
+      case 3:
+         guard let pastSelectionIndexPath = pastSelectionMilestone else {
+            pastSelectionMilestone = indexPath
+            break
+         }
+         collectionView.deselectItem(at: pastSelectionIndexPath, animated: true)
+         let cell = collectionView.cellForItem(at: pastSelectionIndexPath) as? FilterListCollectionViewCell
+         cell?.setDeselected()
+         pastSelectionMilestone = indexPath
+      
+      default: break
+      }
+      
+      print(collectionView.indexPathsForSelectedItems)
       cell.setSelected()
    }
    
-   func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+   func collectionView(_ collectionView: UICollectionView,
+                       didDeselectItemAt indexPath: IndexPath) {
       guard let cell = collectionView.cellForItem(at: indexPath) as? FilterListCollectionViewCell else {
          return
       }

--- a/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/Filter/FilterListViewController.swift
@@ -54,6 +54,15 @@ class FilterListViewController: UIViewController {
    }
    
    @IBAction func save(_ sender: Any) {
+      let filterElements = collectionView.indexPathsForSelectedItems
+      filterElements?.forEach {
+         filterApplyList.addFilter(section: $0.section,
+                                   id: filterListUseCase?.sendItemId(section: $0.section, index: $0.row))
+      }
+      
+      NotificationCenter.default.post(name: FilterApplyList.applyFilter,
+                                            object: nil,
+                                            userInfo: [0 : filterApplyList])
       
       self.dismiss(animated: true)
    }

--- a/ios/IssueTracker/IssueTracker/IssueTab/List/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueTab/List/IssueListViewController.swift
@@ -17,7 +17,7 @@ class IssueListViewController: UIViewController {
    
    var networkManager: NetworkManager?
    private var list: IssueList = IssueList()
-   var fetchedAllData = IssueListDTO()
+   private var filterList = IssueFilterList()
    
    var currentPageNumber: Int = 0
    var isPaging = false
@@ -185,7 +185,7 @@ extension IssueListViewController {
             self?.list.emptyList()
             let newIssues = ListingItemFactory.IssueTab.makeIssues(with: dto.issues)
             self?.list.add(issues: newIssues) // -> POST NOTIFICATION
-            self?.fetchedAllData = dto
+            self?.filterList = FilterListFactory.make(issueList: dto)
             self?.currentPageNumber += 1
          }
       }
@@ -206,8 +206,10 @@ extension IssueListViewController {
 // MARK: - Filter
 
 extension IssueListViewController: DataSenderDelegate {
-   func receive() -> IssueListDTO {
-      fetchedAllData
+   typealias DataType = IssueFilterList
+   
+   func send() -> IssueFilterList {
+      filterList
    }
 }
 

--- a/ios/IssueTracker/IssueTracker/Model/IssueFilterList.swift
+++ b/ios/IssueTracker/IssueTracker/Model/IssueFilterList.swift
@@ -8,15 +8,18 @@
 import Foundation
 
 struct IssueFilterList {
+   var headerList: [String]
    var statusList: [String]
    var userList: [IssueListDTO.User]
    var labelList: [IssueListDTO.Label]
    var milestoneList: [IssueListDTO.Milestone]
    
-   init(statusList: [String] = ["열린 이슈", "내가 작성한 이슈", "내가 댓글을 남긴 이슈", "닫힌 이슈"],
+   init(headerList: [String] = ["상태", "담당자", "레이블", "마일스톤"],
+        statusList: [String] = ["열린 이슈", "내가 작성한 이슈", "내가 댓글을 남긴 이슈", "닫힌 이슈"],
         userList: [IssueListDTO.User] = [],
         labelList: [IssueListDTO.Label] = [],
         milestoneList: [IssueListDTO.Milestone] = []) {
+      self.headerList = headerList
       self.statusList = statusList
       self.userList = userList
       self.labelList = labelList

--- a/ios/IssueTracker/IssueTracker/Model/IssueFilterList.swift
+++ b/ios/IssueTracker/IssueTracker/Model/IssueFilterList.swift
@@ -1,0 +1,25 @@
+//
+//  IssueFilterList.swift
+//  IssueTracker
+//
+//  Created by Wood on 2023/05/28.
+//
+
+import Foundation
+
+struct IssueFilterList {
+   var statusList: [String]
+   var userList: [IssueListDTO.User]
+   var labelList: [IssueListDTO.Label]
+   var milestoneList: [IssueListDTO.Milestone]
+   
+   init(statusList: [String] = ["열린 이슈", "내가 작성한 이슈", "내가 댓글을 남긴 이슈", "닫힌 이슈"],
+        userList: [IssueListDTO.User] = [],
+        labelList: [IssueListDTO.Label] = [],
+        milestoneList: [IssueListDTO.Milestone] = []) {
+      self.statusList = statusList
+      self.userList = userList
+      self.labelList = labelList
+      self.milestoneList = milestoneList
+   }
+}

--- a/ios/IssueTracker/IssueTracker/Model/IssueList.swift
+++ b/ios/IssueTracker/IssueTracker/Model/IssueList.swift
@@ -70,6 +70,7 @@ extension IssueList {
       static let didAddIssues = Notification.Name(rawValue: "didAddIssues")
       static let didOpenIssue = Notification.Name("didOpenIssue")
       static let didCloseIssue = Notification.Name("didCloseIssue")
+      static let didAddFilteredIssues = Notification.Name(rawValue: "didAddFilteredIssues")
    }
    
    enum Keys {
@@ -79,17 +80,19 @@ extension IssueList {
 }
 
 extension IssueList {
-   private func append(_ newIssues: [Issue]) {
+   private func append(_ newIssues: [Issue], _ isFiltered: Bool = false) {
       self.issues.append(contentsOf: newIssues)
       
+      let notiName = isFiltered ? Notifications.didAddFilteredIssues : Notifications.didAddIssues
+      
       NotificationCenter.default.post(
-         name: Notifications.didAddIssues,
+         name: notiName,
          object: self,
          userInfo: [Keys.Issues: self.issues])
    }
    
-   func add(issues: [Issue]) {
-      self.append(issues)
+   func add(issues: [Issue], isFiltered: Bool = false) {
+      self.append(issues, isFiltered)
    }
    
    private func append(_ issue: Issue) {

--- a/ios/IssueTracker/IssueTracker/Network/DTO/IssueListDTO.swift
+++ b/ios/IssueTracker/IssueTracker/Network/DTO/IssueListDTO.swift
@@ -29,7 +29,7 @@ struct IssueListDTO: Codable {
       }
    }
    
-   struct User: Codable {
+   struct User: Codable, Hashable {
       let userId: Int
       let userName: String
       let profileUrl: String?

--- a/ios/IssueTracker/IssueTracker/Network/NetworkManager.swift
+++ b/ios/IssueTracker/IssueTracker/Network/NetworkManager.swift
@@ -89,6 +89,50 @@ final class NetworkManager {
          }
       }
    }
+
+   func requestIssueList(filterList: FilterApplyList, pageNumber: Int? = nil, completion: @escaping (IssueListDTO) -> Void) {
+      var query: [String: String] = [:]
+
+      let filterList = filterList
+      let statusString = filterList.status ? "open" : "closed"
+      query.updateValue("\(statusString)", forKey: "status")
+      
+      var userString = ""
+      filterList.users.forEach {
+         userString += String($0) + ","
+      }
+      userString = String(userString.dropLast())
+      query.updateValue("\(userString)", forKey: "assignee")
+      
+      var labelString = ""
+      filterList.labels.forEach {
+         labelString += String($0) + ","
+      }
+      labelString = String(labelString.dropLast())
+      query.updateValue("\(labelString)", forKey: "label")
+      
+      if let milestoneString = filterList.milestone {
+         query.updateValue("\(milestoneString)", forKey: "milestone")
+      }
+
+      if let pageNumber {
+         query.updateValue("\(Self.defaultPagingOffSet)", forKey: "offset")
+         query.updateValue("\(pageNumber)", forKey: "pageNum")
+      }
+
+      let issueListURL = baseURL + "/issues"
+
+      fetchData(for: issueListURL,
+                with: query,
+                dataType: IssueListDTO.self) { result in
+         switch result {
+         case .success(let issueList):
+            completion(issueList)
+         case .failure(let error):
+            print(error)
+         }
+      }
+   }
    
    func requestIssueDetail(issueId: Int, completion: @escaping (IssueDetailDTO) -> Void) {
       let issueDetailURL = baseURL + "/issues/\(issueId)"


### PR DESCRIPTION
## 키워드
- 필터 목록에서 다중 선택이 가능하도록 했습니다. (일부는 단일 선택)
   - 단일선택 Section: 상태, 마일스톤
- 적용 버튼 클릭시 필터 목록 > 이슈 목록 데이터를 전송합니다.
- 필터를 반영한 URL 쿼리문을 기반으로 데이터를 로드하도록 구현했습니다.
- 옵저버 패턴을 이용하여 반영된 데이터를 기반으로 콜렉션 뷰를 다시 로드합니다.

지금 데이터 로드가 불가능해 추후에 실행 안될경우 Fix 하도록 하겠습니다.